### PR TITLE
fix android holo theme in FF

### DIFF
--- a/toggle-switch.css
+++ b/toggle-switch.css
@@ -317,7 +317,7 @@ https://github.com/ghinda/css-toggle-switch
 		-moz-transform: skew(20deg) translateX(10px);
 		-ms-transform: skew(20deg) translateX(10px);
 		-o-transform: skew(20deg) translateX(10px);
-		transform: skew(20deg);
+		transform: skew(20deg) translateX(10px);
 	}
 
 	.android.toggle .slide-button {
@@ -350,6 +350,12 @@ https://github.com/ghinda/css-toggle-switch
 	.android.switch,
 	.android span {
 		text-transform: uppercase;
+	}
+
+	/* Fix Android/Holo Theme in firefox - force absolute position */
+	.android.switch input {
+		top: 0;
+		left: 0;
 	}
 
 	/* iOS Theme


### PR DESCRIPTION
Hi, 

Some small bugfixes. I've added a css rule to fix the android / Holo switch visualization in Firefox and, also, the  translateX(10px) to the generic transform rule in ".android.switch .slide-button" (latest FF and IE use it instead of the vendor prefixed).

I love this toggle switches, I will definitely use them :) 

Thank you!
