### PR TITLE
Add color transition effect for labels, to make it more graceful

### DIFF
--- a/dist/toggle-switch.css
+++ b/dist/toggle-switch.css
@@ -68,6 +68,10 @@
     z-index: 3;
     display: block;
     width: 100%;
+    -webkit-transition: color 0.3s ease-out;
+    -moz-transition: color 0.3s ease-out;
+    -o-transition: color 0.3s ease-out;
+    transition: color 0.3s ease-out;
   }
   .toggle input {
     position: absolute;
@@ -153,6 +157,10 @@
     height: 100%;
     margin: 0;
     text-align: center;
+    -webkit-transition: color 0.3s ease-out;
+    -moz-transition: color 0.3s ease-out;
+    -o-transition: color 0.3s ease-out;
+    transition: color 0.3s ease-out;
   }
   .switch .slide-button {
     position: absolute;

--- a/src/toggle-switch.scss
+++ b/src/toggle-switch.scss
@@ -63,6 +63,7 @@
 
 		display: block;
 		width: 100%;
+		@include transition(color 0.3s ease-out);
 	}
 
 	/* Don't hide the input from screen-readers and keyboard access
@@ -145,6 +146,7 @@
 
 		margin: 0;
 		text-align: center;
+		@include transition(color 0.3s ease-out);
 	}
 
 	.slide-button {


### PR DESCRIPTION
I am using the css-toggle-switch in my web page. It is really very nice.

My designer finds it more graceful with a transition if the label's `<span>` changes color during toggle/switch.

The transition time is equal to slide-button's ( 0.3 s ).
