### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ With [npm](https://www.npmjs.com/package/css-toggle-switch): `npm install --save
 From [jsDelivr](https://www.jsdelivr.com/projects/css-toggle-switch)
 
 ```
-<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/css-toggle-switch/latest/toggle-switch.css" />
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/css-toggle-switch@latest/dist/toggle-switch.css" />
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "css-toggle-switch",
   "version": "4.1.0",
+  "jsdelivr": "dist/toggle-switch.css",
   "repository": {
     "type": "git",
     "url": "https://github.com/ghinda/css-toggle-switch.git"


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.
I also set the default file to `dist/toggle-switch.css`.

You can find links for all files at https://www.jsdelivr.com/package/npm/css-toggle-switch.

Feel free to ping me if you have any questions regarding this change.